### PR TITLE
feat: reverted changes to email

### DIFF
--- a/backend/api/Controllers/UserController.cs
+++ b/backend/api/Controllers/UserController.cs
@@ -23,6 +23,11 @@ public class UserController : ControllerBase
 	[HttpPost]
 	public async Task<ActionResult<UserResponseDto>> Register([FromBody] RegisterRequestDto registerRequest)
 	{
+		if (!registerRequest.Password.Equals(registerRequest.Password2))
+		{
+			return BadRequest("Passwords are not matching");
+		}
+		
 		var existingUsername = await _userRepository.GetByUsername(registerRequest.Username);
 		var existingMail = await _userRepository.GetByEmail(registerRequest.Email);
 

--- a/backend/api/Controllers/UserController.cs
+++ b/backend/api/Controllers/UserController.cs
@@ -30,7 +30,7 @@ public class UserController : ControllerBase
 		{
 			return BadRequest("Username is already taken");
 		}
-		
+
 		if (existingMail != null)
 		{
 			return BadRequest("Email already taken");

--- a/backend/api/Controllers/UserController.cs
+++ b/backend/api/Controllers/UserController.cs
@@ -27,7 +27,7 @@ public class UserController : ControllerBase
 		{
 			return BadRequest("Passwords are not matching");
 		}
-		
+
 		var existingUsername = await _userRepository.GetByUsername(registerRequest.Username);
 		var existingMail = await _userRepository.GetByEmail(registerRequest.Email);
 

--- a/backend/api/Controllers/UserController.cs
+++ b/backend/api/Controllers/UserController.cs
@@ -24,15 +24,26 @@ public class UserController : ControllerBase
 	public async Task<ActionResult<UserResponseDto>> Register([FromBody] RegisterRequestDto registerRequest)
 	{
 		var existingUsername = await _userRepository.GetByUsername(registerRequest.Username);
+		var existingMail = await _userRepository.GetByEmail(registerRequest.Email);
 
 		if (existingUsername != null)
 		{
 			return BadRequest("Username is already taken");
 		}
+		
+		if (existingMail != null)
+		{
+			return BadRequest("Email already taken");
+		}
 
 		var hashedPassword = _passwordHasher.Hash(registerRequest.Password);
 
-		var newUser = new User { Username = registerRequest.Username, Password = hashedPassword, };
+		var newUser = new User
+		{
+			Username = registerRequest.Username,
+			Email = registerRequest.Email,
+			Password = hashedPassword,
+		};
 
 		await _userRepository.CreateUser(newUser);
 		var userDto = new UserResponseDto(newUser.Username, newUser.Email);

--- a/backend/api/Migrations/20240920202921_email-revert.Designer.cs
+++ b/backend/api/Migrations/20240920202921_email-revert.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using api.Data;
 
@@ -11,9 +12,11 @@ using api.Data;
 namespace api.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20240920202921_email-revert")]
+    partial class emailrevert
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/api/Migrations/20240920202921_email-revert.cs
+++ b/backend/api/Migrations/20240920202921_email-revert.cs
@@ -4,43 +4,35 @@
 
 namespace api.Migrations
 {
-    /// <inheritdoc />
-    public partial class emailrevert : Migration
-    {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.UpdateData(
-                table: "users",
-                keyColumn: "email",
-                keyValue: null,
-                column: "email",
-                value: "");
+	/// <inheritdoc />
+	public partial class emailrevert : Migration
+	{
+		/// <inheritdoc />
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.UpdateData(table: "users", keyColumn: "email", keyValue: null, column: "email", value: "");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "email",
-                table: "users",
-                type: "varchar(255)",
-                nullable: false,
-                oldClrType: typeof(string),
-                oldType: "varchar(255)",
-                oldNullable: true)
-                .Annotation("MySql:CharSet", "utf8mb4")
-                .OldAnnotation("MySql:CharSet", "utf8mb4");
-        }
+			migrationBuilder
+				.AlterColumn<string>(
+					name: "email",
+					table: "users",
+					type: "varchar(255)",
+					nullable: false,
+					oldClrType: typeof(string),
+					oldType: "varchar(255)",
+					oldNullable: true
+				)
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+		}
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.AlterColumn<string>(
-                name: "email",
-                table: "users",
-                type: "varchar(255)",
-                nullable: true,
-                oldClrType: typeof(string),
-                oldType: "varchar(255)")
-                .Annotation("MySql:CharSet", "utf8mb4")
-                .OldAnnotation("MySql:CharSet", "utf8mb4");
-        }
-    }
+		/// <inheritdoc />
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder
+				.AlterColumn<string>(name: "email", table: "users", type: "varchar(255)", nullable: true, oldClrType: typeof(string), oldType: "varchar(255)")
+				.Annotation("MySql:CharSet", "utf8mb4")
+				.OldAnnotation("MySql:CharSet", "utf8mb4");
+		}
+	}
 }

--- a/backend/api/Migrations/20240920202921_email-revert.cs
+++ b/backend/api/Migrations/20240920202921_email-revert.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace api.Migrations
+{
+    /// <inheritdoc />
+    public partial class emailrevert : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "users",
+                keyColumn: "email",
+                keyValue: null,
+                column: "email",
+                value: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "email",
+                table: "users",
+                type: "varchar(255)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(255)",
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "email",
+                table: "users",
+                type: "varchar(255)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(255)")
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}

--- a/backend/api/Models/DTOs/RegisterRequestDto.cs
+++ b/backend/api/Models/DTOs/RegisterRequestDto.cs
@@ -1,3 +1,3 @@
 ﻿namespace api.Models.DTOs;
 
-public record RegisterRequestDto(string Username, string Email, string Password);
+public record RegisterRequestDto(string Username, string Email, string Password, string? Password2);

--- a/backend/api/Models/DTOs/RegisterRequestDto.cs
+++ b/backend/api/Models/DTOs/RegisterRequestDto.cs
@@ -1,3 +1,3 @@
 ﻿namespace api.Models.DTOs;
 
-public record RegisterRequestDto(string Username, string Password);
+public record RegisterRequestDto(string Username, string Email, string Password);

--- a/backend/api/Models/DTOs/UserResponseDto.cs
+++ b/backend/api/Models/DTOs/UserResponseDto.cs
@@ -1,3 +1,3 @@
 ﻿namespace api.Models.DTOs;
 
-public record UserResponseDto(string Username, string? Email);
+public record UserResponseDto(string Username, string Email);

--- a/backend/api/Models/Entities/User.cs
+++ b/backend/api/Models/Entities/User.cs
@@ -18,7 +18,9 @@ public class User
 	public string Username { get; set; }
 
 	[Column("email")]
-	public string? Email { get; set; }
+	[EmailAddress]
+	[Required]
+	public string Email { get; set; }
 
 	[Required]
 	[Column("password")]

--- a/backend/api/Services/JwtGenerator.cs
+++ b/backend/api/Services/JwtGenerator.cs
@@ -26,7 +26,7 @@ public class JwtGenerator : IJwtGenerator
 			new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
 			new Claim("userId", user.Id.ToString()),
 			new Claim("username", user.Username),
-			new Claim("email", user.Email ?? ""),
+			new Claim("email", user.Email),
 		};
 
 		// TODO: Save Jwt key somewhere more secure

--- a/backend/tests/UserTests.cs
+++ b/backend/tests/UserTests.cs
@@ -29,7 +29,7 @@ public class UserTests
 	{
 		// Arrange
 		var userInDb = new User { Email = "Test2@gmail.com", Username = "Test Name" };
-		var requestDto = new RegisterRequestDto("Test Name", "Test@gmail.com", "TestPassword");
+		var requestDto = new RegisterRequestDto("Test Name", "Test@gmail.com", "TestPassword", "TestPassword");
 		_userRepositoryMock.GetByUsername(requestDto.Username).Returns(userInDb);
 		_userRepositoryMock.GetByEmail(requestDto.Email).Returns(Task.FromResult<User?>(null));
 
@@ -45,7 +45,7 @@ public class UserTests
 	{
 		// Arrange
 		var userInDb = new User { Email = "Joe@gmail.com", Username = "Johan" };
-		var requestDto = new RegisterRequestDto("Jamal", "Joe@gmail.com", "TestPassword");
+		var requestDto = new RegisterRequestDto("Jamal", "Joe@gmail.com", "TestPassword", "TestPassword");
 		_userRepositoryMock.GetByEmail(requestDto.Email).Returns(userInDb);
 		_userRepositoryMock.GetByUsername(requestDto.Username).Returns(Task.FromResult<User?>(null));
 
@@ -60,7 +60,7 @@ public class UserTests
 	public async Task Register_New_User_Should_Success()
 	{
 		// Arrange
-		var requestDto = new RegisterRequestDto("Julie", "Julie@gmail.com", "TestPassword");
+		var requestDto = new RegisterRequestDto("Julie", "Julie@gmail.com", "TestPassword", "TestPassword");
 		var hashedPassword = "hashed";
 		_userRepositoryMock.GetByEmail(requestDto.Email).Returns(Task.FromResult<User?>(null));
 		_userRepositoryMock.GetByUsername(requestDto.Username).Returns(Task.FromResult<User?>(null));
@@ -147,5 +147,18 @@ public class UserTests
 		Assert.Equal(requestDto.Username, response.User.Username);
 		Assert.Equal(userInDb.Email, response.User.Email);
 		Assert.NotNull(response.Token);
+	}
+	
+	[Fact]
+	public async Task Register_Not_Matching_Password_Should_Return_Bad_Request()
+	{
+		// Arrange
+		var requestDto = new RegisterRequestDto("Test Name", "Test@gmail.com", "TestPassword", "NotMatchingPassword");
+
+		// Act
+		var result = await _userController.Register(requestDto);
+
+		// Assert
+		Assert.IsType<BadRequestObjectResult>(result.Result);
 	}
 }

--- a/backend/tests/UserTests.cs
+++ b/backend/tests/UserTests.cs
@@ -148,7 +148,7 @@ public class UserTests
 		Assert.Equal(userInDb.Email, response.User.Email);
 		Assert.NotNull(response.Token);
 	}
-	
+
 	[Fact]
 	public async Task Register_Not_Matching_Password_Should_Return_Bad_Request()
 	{

--- a/frontend/src/models/User.ts
+++ b/frontend/src/models/User.ts
@@ -2,5 +2,5 @@
 
 export default interface IUser {
     username: string,
-    email?: string,
+    email: string,
 }

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router-dom";
 
 const INIT_FORM = {
 	username: "",
+	email: "",
 	password: "",
 	passwordRepeat: "",
 };
@@ -21,15 +22,19 @@ function RegisterPage() {
 	};
 
 	const handleSubmit = () => {
-		const { username, password, passwordRepeat } = registerForm;
+		const { username, email, password, passwordRepeat } = registerForm;
 
 		if (password !== passwordRepeat) {
 			setErrorMessage("Password is not matching.");
 			return;
 		}
-		
 
-		const body = { username, password };
+		if (!email.includes("@")) {
+			setErrorMessage("Please insert a valid email.");
+			return;
+		}
+
+		const body = { username, email, password };
 
 		UsersEndpoint.Register(body)
 			.then(() => navigate("/login", { state: { redirected: true } }))
@@ -43,6 +48,9 @@ function RegisterPage() {
 				<div className="flex flex-col items-center gap-4">
 					<div className="flex flex-col">
 						<TextInput required name="username" value={registerForm.username} onChange={handleChange} label="Username:" />
+					</div>
+					<div className="flex flex-col">
+						<TextInput required name="email" value={registerForm.email} onChange={handleChange} label="E-mail:" type="email" />
 					</div>
 					<div className="flex flex-col">
 						<TextInput required name="password" value={registerForm.password} onChange={handleChange} label="Password:" type="password" />

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -34,7 +34,7 @@ function RegisterPage() {
 			return;
 		}
 
-		const body = { username, email, password };
+		const body = { username, email, password, password2: password };
 
 		UsersEndpoint.Register(body)
 			.then(() => navigate("/login", { state: { redirected: true } }))

--- a/frontend/src/services/UsersEndpoint.ts
+++ b/frontend/src/services/UsersEndpoint.ts
@@ -1,7 +1,7 @@
 import IUser from "@/models/User";
 import ApiClient from "./ApiClient";
 
-type TRegisterRequest = { username: string; password: string };
+type TRegisterRequest = { username: string; email: string; password: string };
 type TLoginRequest = { username: string, password: string };
 
 export type LoginResponse = {user: IUser, token: string}

--- a/frontend/src/services/UsersEndpoint.ts
+++ b/frontend/src/services/UsersEndpoint.ts
@@ -1,7 +1,7 @@
 import IUser from "@/models/User";
 import ApiClient from "./ApiClient";
 
-type TRegisterRequest = { username: string; email: string; password: string };
+type TRegisterRequest = { username: string; email: string; password: string, password2: string };
 type TLoginRequest = { username: string, password: string };
 
 export type LoginResponse = {user: IUser, token: string}


### PR DESCRIPTION
# Pull Request

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

#### Nye krav fra Anders:

**POST /api/register manglede email i spec og tydeliggjorte ikke, at password2 var optional.**

Jeg har revertet tilbage til at `Email` ikke længere er nullable. Derudover så sendes der password2 tilbage til backenden for at validere, at `password1.equals(password2)`.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Added/updated tests?

- [x] Yes, added
- [x] Yes, updated
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
