### PR TITLE
Reverted back to GET /api/search with query

### DIFF
--- a/backend/api/Controllers/PageController.cs
+++ b/backend/api/Controllers/PageController.cs
@@ -16,8 +16,7 @@ public class PageController : ControllerBase
 
 	[Route("/api/search")]
 	[HttpGet]
-	public async Task<ActionResult<IEnumerable<PageResponseDto>>> Search([FromQuery] string? q,
-		[FromQuery] string? language = "en")
+	public async Task<ActionResult<IEnumerable<PageResponseDto>>> Search([FromQuery] string? q, [FromQuery] string? language = "en")
 	{
 		var pageResults = await _pageRepository.GetByContent(q, language);
 
@@ -26,9 +25,7 @@ public class PageController : ControllerBase
 			return Ok(new List<PageResponseDto>());
 		}
 
-		var pageResultsDto = pageResults
-			.Select(page => new PageResponseDto(page.Title, page.Url, page.Language, page.Content))
-			.ToList();
+		var pageResultsDto = pageResults.Select(page => new PageResponseDto(page.Title, page.Url, page.Language, page.Content)).ToList();
 
 		return Ok(pageResultsDto);
 	}

--- a/backend/api/Controllers/PageController.cs
+++ b/backend/api/Controllers/PageController.cs
@@ -15,19 +15,20 @@ public class PageController : ControllerBase
 	}
 
 	[Route("/api/search")]
-	[HttpPost]
-	public async Task<ActionResult<IEnumerable<PageResponseDto>>> Search([FromBody] SearchRequestDto searchRequest)
+	[HttpGet]
+	public async Task<ActionResult<IEnumerable<PageResponseDto>>> Search([FromQuery] string? q,
+		[FromQuery] string? language = "en")
 	{
-		var language = searchRequest.Language ?? "en";
-
-		var pageResults = await _pageRepository.GetByContent(searchRequest.Q, language);
+		var pageResults = await _pageRepository.GetByContent(q, language);
 
 		if (pageResults.Count == 0)
 		{
 			return Ok(new List<PageResponseDto>());
 		}
 
-		var pageResultsDto = pageResults.Select(page => new PageResponseDto(page.Title, page.Url, page.Language, page.Content)).ToList();
+		var pageResultsDto = pageResults
+			.Select(page => new PageResponseDto(page.Title, page.Url, page.Language, page.Content))
+			.ToList();
 
 		return Ok(pageResultsDto);
 	}

--- a/backend/api/Models/DTOs/SearchRequestDto.cs
+++ b/backend/api/Models/DTOs/SearchRequestDto.cs
@@ -1,3 +1,0 @@
-﻿namespace api.Models.DTOs;
-
-public record SearchRequestDto(string Q, string? Language = null);

--- a/backend/tests/PageTests.cs
+++ b/backend/tests/PageTests.cs
@@ -20,11 +20,9 @@ public class PageTests : IClassFixture<TestDatabaseFactory>
 	{
 		//Arrange
 		var client = _factory.CreateClient();
-		var body = new SearchRequestDto("script");
-		JsonContent content = JsonContent.Create(body);
 
 		// Act
-		var response = await client.PostAsync("/api/search", content);
+		var response = await client.GetAsync("/api/search?q=JavaScript");
 
 		// Assert
 		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -35,11 +33,9 @@ public class PageTests : IClassFixture<TestDatabaseFactory>
 	{
 		//Arrange
 		var client = _factory.CreateClient();
-		var body = new SearchRequestDto("script", "en");
-		JsonContent content = JsonContent.Create(body);
 
 		// Act
-		var response = await client.PostAsync("/api/search", content);
+		var response = await client.GetAsync("/api/search?q=JavaScript&language=en");
 
 		// Assert
 		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -50,11 +46,9 @@ public class PageTests : IClassFixture<TestDatabaseFactory>
 	{
 		//Arrange
 		var client = _factory.CreateClient();
-		var body = new SearchRequestDto("script");
-		JsonContent content = JsonContent.Create(body);
 
 		// Act
-		var response = await client.PostAsync("/api/search", content);
+		var response = await client.GetAsync("/api/search?q=script");
 		var pages = await response.Content.ReadFromJsonAsync<List<Page>>();
 
 		// Assert
@@ -72,11 +66,9 @@ public class PageTests : IClassFixture<TestDatabaseFactory>
 	{
 		//Arrange
 		var client = _factory.CreateClient();
-		var body = new SearchRequestDto("leverpostej");
-		JsonContent content = JsonContent.Create(body);
 
 		// Act
-		var response = await client.PostAsync("/api/search", content);
+		var response = await client.GetAsync("/api/search?q=leverpostej");
 		var pages = await response.Content.ReadFromJsonAsync<List<Page>>();
 
 		// Assert

--- a/frontend/src/services/PagesEndpoint.ts
+++ b/frontend/src/services/PagesEndpoint.ts
@@ -1,19 +1,9 @@
 import IPage from "@/models/Page";
 import ApiClient from "./ApiClient";
 
-type TPagesRequest = {
-	q: string,
-	language?: string
-}
-
 class PagesEndpoint {
-
 	static async getPages(searchValue: string, language: string = "en"): Promise<IPage[]> {
-		const body: TPagesRequest = {
-			q: searchValue,
-			language: language
-		}
-		const resp = await new ApiClient().Post<IPage[], TPagesRequest>("api/search", body);
+		const resp = await new ApiClient().Get<IPage[]>("api/search", { q: searchValue, language });
 
 		if (!resp.ok) {
 			throw new Error(resp.error);


### PR DESCRIPTION
# Pull Request

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

#### Nye krav fra Anders:

**I spec og Flask applikationen er det GET /api/search, men simulatoren havde sat det som POST /api/search. 
Det blev også påpeget til undervisningen, men jeg forstod det mere som en præference og ikke, at simulatoren afvej fra resten. 
Løsning: Simulatoren er opdateret og kører nu /api/search på GET og q er et query parameter.**

Jeg har revertet tilbage til `GET /api/search` med queries i stedet for POST med body.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Added/updated tests?

- [x] Yes, added
- [x] Yes, updated
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
